### PR TITLE
fix: remove extra margin.

### DIFF
--- a/src/window/layer/PoCoLayerTableView.h
+++ b/src/window/layer/PoCoLayerTableView.h
@@ -1,8 +1,9 @@
 //
-//	Pelistina on Cocoa - PoCo -
-//	レイヤー一覧テーブル
+// PoCoLayerTableView.h
+// declare interface of PoCoLayerTableView class.
+// this class is to manage PoCoLayerTableView.
 //
-//	Copyright (C) 2005-2018 KAENRYUU Koutoku.
+// Copyright (C) 2005-2025 KAENRYUU Koutoku.
 //
 
 #import <Cocoa/Cocoa.h>
@@ -14,6 +15,9 @@
     BOOL isRightDown_;                  // 副ボタン押し下
     int startRow_;                      // 移動開始行
 }
+
+// awake from nib.
+- (void)awakeFromNib;
 
 // 表示要求
 -(void)drawRect:(NSRect)rect;

--- a/src/window/layer/PoCoLayerTableView.m
+++ b/src/window/layer/PoCoLayerTableView.m
@@ -1,8 +1,8 @@
 //
-//	Pelistina on Cocoa - PoCo -
-//	レイヤー一覧テーブル
+// PoCoLayerTableView.m
+// implementation of PoCoLayerTableView class.
 //
-//	Copyright (C) 2005-2018 KAENRYUU Koutoku.
+// Copyright (C) 2005-2025 KAENRYUU Koutoku.
 //
 
 #import "PoCoLayerTableView.h"
@@ -43,6 +43,27 @@
 
 
 // ---------------------------------------------------------- instance - public
+//
+// awake from nib.
+//
+//  Call:
+//    none.
+//
+//  Return:
+//    none.
+//
+- (void)awakeFromNib
+{
+    // forwaed to super class.
+    [super awakeFromNib];
+    
+    // override style.
+    [self setStyle:NSTableViewStylePlain];
+    
+    return;
+}
+
+
 //
 // 表示要求
 //


### PR DESCRIPTION
ref #8.

to remove extra margin on TableView, override style when awake from nib.
I think that this is affected by default behaviour changed (Apps that link to previous macOS versions default to NSTableViewStylePlain).