### PR TITLE
fix: fix an issue

### DIFF
--- a/src/PoCoAppController.h
+++ b/src/PoCoAppController.h
@@ -28,7 +28,8 @@
 @class PoCoTileSteadyPattern;
 
 // ----------------------------------------------------------------------------
-@interface PoCoAppController : NSObject {
+@interface PoCoAppController : NSObject <NSMenuItemValidation>
+{
     BOOL willFinish_;                   // 終了処理中か
 
     // 各補助・設定パネルの管理用 instance 変数

--- a/src/mainview/PoCoView.h
+++ b/src/mainview/PoCoView.h
@@ -15,7 +15,7 @@
 @class PoCoDrawBase;
 
 // ----------------------------------------------------------------------------
-@interface PoCoView : NSView
+@interface PoCoView : NSView <NSMenuItemValidation>
 {
     IBOutlet NSSlider *slider_;         // 倍率の slider
     IBOutlet MyDocument *document_;     // 編集対象の元締め

--- a/src/window/layer/PoCoLayerTableView.h
+++ b/src/window/layer/PoCoLayerTableView.h
@@ -9,7 +9,7 @@
 #import <Cocoa/Cocoa.h>
 
 // ----------------------------------------------------------------------------
-@interface PoCoLayerTableView : NSTableView
+@interface PoCoLayerTableView : NSTableView <NSMenuItemValidation>
 {
     BOOL isMoving_;                     // YES : 移動操作    NO : 通常操作
     BOOL isRightDown_;                  // 副ボタン押し下

--- a/src/window/layer/PoCoLayerTableView.m
+++ b/src/window/layer/PoCoLayerTableView.m
@@ -128,11 +128,11 @@
 -(BOOL)validateMenuItem:(NSMenuItem *)menu
 {
     BOOL result;
+    
+    result = YES;
 
     if ([menu action] == @selector(selectAll:)) {
         result = ((PoCoView *)([(MyDocument *)([[NSDocumentController sharedDocumentController] currentDocument]) view]) != nil);
-    } else {
-        result = [super validateMenuItem:menu];
     }
 
     return result;


### PR DESCRIPTION
ref #39.

fix an issue of the deprecated method `validateMenuItem` of NSObject.
Apply `NSMenuItemValidation` protocol to `PoCoView`, `PoCoAppController`, and `PoCoLayerTableView`. 
And, in `PoCoLayerTableView`, do not forward `validateMenuItem` to super class.