### PR TITLE
feat: implement the migration path against `NSUnarchiver` deprecation.

### DIFF
--- a/src/mono/PoCoPenStyle.h
+++ b/src/mono/PoCoPenStyle.h
@@ -19,7 +19,7 @@
 +(void)initialize;
 
 // initialize
--(id)init;
+- (id)init;
 
 // deallocate
 -(void)dealloc;

--- a/src/mono/PoCoTilePattern.h
+++ b/src/mono/PoCoTilePattern.h
@@ -19,7 +19,7 @@
 +(void)initialize;
 
 // initialize
--(id)init;
+- (id)init;
 
 // deallocate
 -(void)dealloc;

--- a/src/mono/PoCoTilePattern.m
+++ b/src/mono/PoCoTilePattern.m
@@ -85,37 +85,61 @@ static void  setPattern(PoCoMonochromePattern *pat, int i)
 // instance - public.
 
 //
-// initialize
+// initialise.
 //
-//  Call
-//    None
+//  Call:
+//    none.
 //
-//  Return
-//    function   : 実体
-//    pattern_[] : ペン先(instance 変数)
+//  Return:
+//    function   : instance.
+//    pattern_[] : tile patterns.(instance)
 //
--(id)init
+-(id) init
 {
     int l;
     NSUserDefaults *def;
+    NSData *data;
+    PoCoMonochromePattern *pat;
+    NSData *newData;
+
 
     DPRINT((@"[PoCoTilePattern init]\n"));
 
-    // super class の初期化
+    // forward to super class.
     self = [super init];
 
-    // 自身の初期化
+    // initialise myself.
     if (self != nil) {
         for (l = 0; l < TILE_PATTERN_NUM; (l)++) {
             self->pattern_[l] = nil;
         }
 
-        // ペン先の読み込み
+        // load each tile pattern from UserDefaults.
         def = [NSUserDefaults standardUserDefaults];
         for (l = 0; l < TILE_PATTERN_NUM; (l)++) {
-            self->pattern_[l] = [NSKeyedUnarchiver unarchivedObjectOfClass:[PoCoMonochromePattern class]
-                                                                  fromData:[def objectForKey:[NSString stringWithFormat:PATTERN_NAME, l]]
-                                                                     error:nil];
+            // retrieve pen style with key.
+            data = [def objectForKey:[NSString stringWithFormat:PATTERN_NAME, l]];
+
+            // unarichve data.
+            pat = [NSKeyedUnarchiver unarchivedObjectOfClass:[PoCoMonochromePattern class]
+                                                    fromData:data
+                                                       error:nil];
+
+            // whether data could be unarchived.
+            if (pat == nil) {
+                // could not be unarchied, then assuming that this is old version. so that, convert data unarchived to current class.
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                pat = [NSUnarchiver unarchiveObjectWithData:data];
+# pragma clang diagnostic pop
+                newData = [NSKeyedArchiver archivedDataWithRootObject:pat
+                                                requiringSecureCoding:YES
+                                                                error:nil];
+                [def setObject:newData
+                        forKey:[NSString stringWithFormat:PATTERN_NAME, l]];
+                [def synchronize];
+            }
+            self->pattern_[l] = pat;
             if (self->pattern_[l] == nil) {
                 DPRINT((@"can't create tile pattern : %d\n", l));
                 [self release];


### PR DESCRIPTION
ref #45.

---
(quotation from #45.)
> However, although NSArchiver and NSUnarchiver are marked deprecated, a class that can unarchive a data created with NSArchiver is NSUnarchiver only (AFAIK).
> So that, this migration path has no choice but to use NSUnarchiver.